### PR TITLE
Avoid 'PHP Notice: Indirect modification of overloaded property'

### DIFF
--- a/RegexFun.php
+++ b/RegexFun.php
@@ -201,15 +201,6 @@ class ExtRegexFun {
 		return false;
 	}
 
-	private static function limitHandler( Parser &$parser ) {
-		// is the limit exceeded for this parsers parse() process?
-		if( self::limitExceeded( $parser ) ) {
-			return false;
-		}
-		self::increaseRegexCount( $parser );
-		return true;
-	}
-
 	/**
 	 * Returns a valid parser function output that the given pattern is not valid for a regular
 	 * expression. The message can be displayed in the wiki and is wrapped in an error-class span
@@ -717,14 +708,7 @@ class ExtRegexFun {
 	}
 
 	public static function onParserClearState( &$parser ) {
-		//cleanup to avoid conflicts with job queue or Special:Import
-		/*
-		$parser->mExtRegexFun = array();
-		self::setLastMatches( $parser, null );
-		self::setLastPattern( $parser, '' );
-		self::setLastSubject( $parser, '' );
-		*/
-		$parser->mExtRegexFun['counter'] = 0;
+		$parser->mExtRegexFun = [ 'counter' => 0 ];
 
 		return true;
 	}
@@ -739,7 +723,7 @@ class ExtRegexFun {
 		global $egRegexFunMaxRegexPerParse;
 		return (
 			$egRegexFunMaxRegexPerParse !== -1
-			&& $parser->mExtRegexFun['counter'] >= $egRegexFunMaxRegexPerParse
+			&& ( $parser->mExtRegexFun['counter'] ?? 0 ) >= $egRegexFunMaxRegexPerParse
 		);
 	}
 
@@ -751,6 +735,10 @@ class ExtRegexFun {
 	}
 
 	private static function increaseRegexCount( Parser &$parser ) {
+		if ( !isset( $parser->mExtRegexFun['counter'] ) ) {
+			$parser->mExtRegexFun = [ 'counter' => 0 ];
+		}
+
 		$parser->mExtRegexFun['counter']++;
 	}
 


### PR DESCRIPTION
In MW 1.37, accessing dynamic fields on Parser goes through
DeprecationHelper, which overrides __get() to return a placeholder
value if the field wasn't yet defined - causing a
'PHP Notice: Indirect modification of overloaded property' if an
attempt is made to mutate such a field without declaring it first.
Fix it by explicitly setting mExtRegexFun on first access.